### PR TITLE
Remove license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(name="omero-weberror",
           'Environment :: Web Environment',
           'Framework :: Django',
           'Intended Audience :: Developers',
-          'License :: OSI Approved :: GNU Affero General Public License v3.0',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Programming Language :: JavaScript',
@@ -59,6 +58,7 @@ setup(name="omero-weberror",
           'Topic :: Text Processing :: Markup :: HTML'
       ],  # Get strings from
           # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+          # 'License :: OSI Approved :: GNU Affero General Public License v3.0',
       author='The Open Microscopy Team',
       author_email='ome-devel@lists.openmicroscopy.org.uk',
       license='AGPL-3.0',


### PR DESCRIPTION
Remove license classifier so the app can be pushed to pypi
``Upload failed (400): Invalid classifier "License :: OSI Approved :: GNU Affero General Public License v3.0"``
The problem has been already reported
I kept it in the file so we can roll the change back later on